### PR TITLE
Updated _getLib function to set the directory based on GetCurrentTemp…

### DIFF
--- a/models/EhCacheProvider.cfc
+++ b/models/EhCacheProvider.cfc
@@ -330,7 +330,7 @@ component extends="coldbox.system.cache.AbstractCacheBoxProvider" implements="co
 	}
 
 	private array function _getLib() {
-		return DirectoryList( ExpandPath( "/cbehcache/lib" ), false, "path", "*.jar" );
+		return DirectoryList( ExpandPath( GetDirectoryFromPath(GetCurrentTemplatePath()) & "../lib" ), false, "path", "*.jar" );
 	}
 
 	private any function _getManager() {


### PR DESCRIPTION
…latePath()

This fixes the bug that jar files are not found when installed in the /application/modules folder